### PR TITLE
jekyll-asciidoc.yml: Install ruby-bundler

### DIFF
--- a/.github/workflows/jekyll-asciidoc.yml
+++ b/.github/workflows/jekyll-asciidoc.yml
@@ -40,6 +40,11 @@ jobs:
           free -h
           dpkg -l
 
+      - name: Install /usr/bin/bundle (/usr/local/bin/bundle is no more)
+        run: |
+          sudo apt update
+          sudo apt install -y ruby-bundler
+
       - name: 🔨 install dependencies & build site
         uses: limjh16/jekyll-action-ts@v2
         with:


### PR DESCRIPTION
to get /usr/bin/bundle as /usr/local/bin/bundle is no more
in the latest GitHub ubuntu-20.04 runner

Fixes #13